### PR TITLE
Citation blockquote element styling

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -114,3 +114,11 @@ Code highlighting
     max-width: min(95vw, 26cm);
   }
 }
+
+blockquote {
+  margin: 0;
+  margin-left: $ksi-margin-small;
+  padding-left: $ksi-padding-small;
+  padding-bottom: $ksi-padding-x-small;
+  border-left: 2px solid $ksi-gray-80;
+}


### PR DESCRIPTION
solves #35 

this now supports blockquotes from text editor when writing discussion post, not our own citations using '>' which would require additional detections and processing of user input.