### PR TITLE
fix(page-results): sort scores by their value

### DIFF
--- a/src/app/components/results/page-results/page-results.component.ts
+++ b/src/app/components/results/page-results/page-results.component.ts
@@ -49,7 +49,7 @@ export class PageResultsComponent implements OnInit {
         });
 
         let previousEndingPos = 1;
-        for (const score of scores) {
+        for (const score of scores.sort((a, b) => b - a)) {
           scorePositions[score] = {
             from: previousEndingPos,
             to: previousEndingPos + scoresCount[score] - 1,


### PR DESCRIPTION
Scoreboard could be sorted as strings instead of numbers, making 123 to be before 23. This fix forces sorting by number value.