### PR TITLE
fix: set text color in sortable item

### DIFF
--- a/src/app/components/tasks/task-module/task-module-sortable/task-module-sortable-item/task-module-sortable-item.component.scss
+++ b/src/app/components/tasks/task-module/task-module-sortable/task-module-sortable-item/task-module-sortable-item.component.scss
@@ -4,6 +4,7 @@
 :host {
   display: block;
   padding: $ksi-margin-small;
+  color: $ksi-gray-30;
 
   border: 1px solid $ksi-blue-200;
   background-color: $ksi-blue-220;


### PR DESCRIPTION
Fixes https://github.com/fi-ksi/web-frontend-angular/issues/81

After change:

white theme:
![image](https://github.com/user-attachments/assets/fa3453f6-a564-4387-9524-4d2b7bfc7b78)

dark theme:
![image](https://github.com/user-attachments/assets/36e6fefa-c1f9-4250-b592-c789544d029b)
