### PR TITLE
feat: implement codeblock line numbering

### DIFF
--- a/src/app/components/tasks/task-body/task-body.component.ts
+++ b/src/app/components/tasks/task-body/task-body.component.ts
@@ -16,6 +16,31 @@ import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { TaskTipComponent } from './task-tip/task-tip.component';
 import { TaskPanel, TaskTipData } from '../../../models';
 
+// https://stackoverflow.com/questions/64280814/how-can-i-correctly-highlight-a-line-by-line-code-using-highlight-js-react
+highlight.addPlugin({
+  'after:highlight': (params: { value: string }) => {
+    const openTags: string[] = [];
+
+    params.value = params.value
+      .split('\n')
+      .map((line) => {
+        line = line.replace(/(<span [^>]+>)|(<\/span>)/g, (match) => {
+          if (match === '</span>') {
+            openTags.pop();
+          } else {
+            openTags.push(match);
+          }
+          return match;
+        });
+
+        return `<div>${openTags.join('')}${line}${'</span>'.repeat(
+          openTags.length
+        )}</div>`;
+      })
+      .join('');
+  },
+});
+
 @Component({
   selector: 'ksi-task-body',
   templateUrl: './task-body.component.html',

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -59,6 +59,25 @@ Codemirror core style
   }
 }
 
+pre.numberLines {
+  counter-reset: line;
+}
+
+pre.numberLines code {
+  display: block;
+}
+
+pre.numberLines code div::before {
+  content: counter(line);
+  counter-increment: line;
+  display: inline-block;
+  text-align: right;
+  color: #999;
+  border-right: 1px solid #ddd;
+  padding: 0 0.5em 0 0.1em;
+  margin-right: 6px;
+}
+
 table {
   th, td {
     color: $ksi-page-fg;


### PR DESCRIPTION
closes https://github.com/fi-ksi/web-frontend-angular/issues/96

```
\```py
print("asd")
print("hello")
\```

\``` {.py .numberLines}
print("asd")
print("huh")

class Trieda:
    def __init__(self):
        pass
\```
```

i'm not sure where to put the highlightjs plugin part but it works now

![image](https://github.com/user-attachments/assets/fda9931d-8929-47b8-ba6c-a7e212b9d147)
